### PR TITLE
Lab 3 fix typo, and add x:Name property

### DIFF
--- a/docs/labor/3-felhasznaloi-felulet/index.md
+++ b/docs/labor/3-felhasznaloi-felulet/index.md
@@ -408,9 +408,9 @@ Definiáljunk a gyökér `Grid`-en 4 sort és 2 oszlopot. Az első oszlopába ke
     </Grid.ColumnDefinitions>
 
     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name"/>
-    <TextBox Grid.Row="0" Grid.Column="1" />
+    <TextBox Grid.Row="0" Grid.Column="1" x:Name="tbName"/>
     <TextBlock Grid.Row="1" Grid.Column="0" Text="Age"/>
-    <TextBox Grid.Row="1" Grid.Column="1" />
+    <TextBox Grid.Row="1" Grid.Column="1" x:Name="tbAge"/>
 
     <Button Grid.Row="2" Grid.Column="1">
         <StackPanel Orientation="Horizontal">
@@ -452,7 +452,7 @@ A felületünk még nem úgy néz ki, mint amit szeretnénk, finomítsunk kicsit
     * `Width="300"`
 * Legyen a sorok között 10px, az oszlopok között 5px távolság és tartsunk 20px távolságot a konténer szélétől
     * `RowSpacing="5" ColumnSpacing="10" Margin="20"`
-* Igazítsuk a címkéket (`TexBlock`) függőlegesen középre
+* Igazítsuk a címkéket (`TextBlock`) függőlegesen középre
     * `VerticalAlignment="Center"`
 * Igazítsuk a gombot jobbra
     * `HorizontalAlignment="Right"`


### PR DESCRIPTION
Azért gondoltam, hogy érdemes az x:Name property-ket az első Grid-es kódrészlethez is hozzáadni, mivel az azután lévő leírásban nem szerepel, hogy ezeket fel kell venni, és a második kiegészített Grid-es kódban ezek már szerepelnek viszont nincsenek highlight-olva. Ha esetleg a diák nem bemásolja teljes egészében a második kódrészletet, hanem próbálja kiegészíteni az elsőt, akkor ez kimaradhat.