### PR TITLE
lab4/Task6.2 - Fix line highlighting for method TryGet

### DIFF
--- a/docs/labor/4-tobbszalu/index.md
+++ b/docs/labor/4-tobbszalu/index.md
@@ -359,7 +359,7 @@ A `DataFifo` osztály szálbiztossá tételéhez szükségünk van egy objektumr
     }
     ```
 
-    ```cs hl_lines="3-4 16"
+    ```cs hl_lines="3-4 13"
     public bool TryGet(out double[] data)
     {
         lock (_syncRoot)


### PR DESCRIPTION
The current line highlighting suggests surrounding the whole method body in a lock. This PR is a fix that shows the correct line.