### PR TITLE
EN/DE/HU typo fix

### DIFF
--- a/docs/hazi/1-model-es-kod-kapcsolata/index_ger.md
+++ b/docs/hazi/1-model-es-kod-kapcsolata/index_ger.md
@@ -167,7 +167,7 @@ Der folgende Code zeigt eine mögliche Lösung, die Details werden in den Codeko
             }
             catch (Exception e)
             {
-                Console.WriteLine("A fájl feldolgozása sikertelen.");
+                Console.WriteLine("Verarbeitung der Datei fehlgeschlagen.");
                 // Die e.Message enhält nur den Text der Ausnahme.
                 // Falls wir jede Information, die zu dieser Ausnahme gehört,
                 // ausschreiben möchten, dann benutzen wir e.ToString()

--- a/docs/hazi/5-mvvm/index_ger.md
+++ b/docs/hazi/5-mvvm/index_ger.md
@@ -20,7 +20,7 @@ Das Ziel der Hausaufgabe:
 - Kennenlernen der Grundlagen des MVVM-Toolkits
 - Üben von XAML-Techniken
 
-Die erforderliche Entwicklungsumgebung wird [hier](.../fejlesztokornyezet/index_ger.md) beschrieben, identisch mit Hausaufgabe 3 (XAML-Grundlagen).
+Die erforderliche Entwicklungsumgebung wird [hier](../fejlesztokornyezet/index_ger.md) beschrieben, identisch mit Hausaufgabe 3 (XAML-Grundlagen).
 
 ## Das Verfahren der Eingabe
 

--- a/docs/hazi/fejlesztokornyezet/index_ger.md
+++ b/docs/hazi/fejlesztokornyezet/index_ger.md
@@ -25,7 +25,7 @@ In der ersten Vorlesung des Kurses werden kurz die verschiedenen Versionen von .
 1. Starten Sie das Visual Studio-Installationsprogramm (z. B. durch Eingabe von "Visual Studio Installer" im Windows-Startmenü).
 2. Klicken Sie auf die Schaltfläche Ändern
 3. Vergewissern Sie sich in dem nun erscheinenden Fenster, dass die Karte **".NET-Desktop-Entwicklung"** aktiviert ist.
-4. Wenn nicht, entfernen Sie das Häkchen und klicken Sie unten rechts auf *Ändern*, um es zu installieren.
+4. Wenn nicht, setzen Sie das Häkchen und klicken Sie unten rechts auf *Ändern*, um es zu installieren.
 
 #### Unterstützung von Klassendiagrammen
 
@@ -34,8 +34,8 @@ Für bestimmte Hausaufgaben (sogar für die erste) benötigen Sie die Unterstüt
 1. Starten Sie das Visual Studio-Installationsprogramm (z. B. durch Eingabe von "Visual Studio Installer" im Windows-Startmenü).
 2. Klicken Sie auf die Schaltfläche Ändern
 3. Wählen Sie in dem nun erscheinenden Fenster die Registerkarte "Einzelne Komponenten"
-4. Geben Sie in das Suchfeld "Klassendesigner" ein und vergewissern Sie sich, dass "Klassendesigner" in der gefilterten Liste nicht angekreuzt ist.
-5. Wenn nicht, entfernen Sie das Häkchen und klicken Sie unten rechts auf *Ändern*, um es zu installieren.
+4. Geben Sie in das Suchfeld "Klassendesigner" ein und vergewissern Sie sich, dass "Klassendesigner" in der gefilterten Liste angekreuzt ist.
+5. Wenn nicht, setzen Sie das Häkchen und klicken Sie unten rechts auf *Ändern*, um es zu installieren.
 
     ![TableDiagram Unterstützung Installation](images/install-vs-class-diagram.png)
 

--- a/docs/labor/3-felhasznaloi-felulet/index_eng.md
+++ b/docs/labor/3-felhasznaloi-felulet/index_eng.md
@@ -667,8 +667,8 @@ Start the application, then set a breakpoint in the setter of the `Name` propert
 This happens because earlier we used `OneWay` data binding, which only means data binding from the data source to the UI. If we want the data binding to work in the reverse direction as well (from control to data source), we need to set the binding mode to **`TwoWay`**. This is called **two-way data binding**.
 
 ```xml
-Text="{x:Bind Name, Mode=TwoWay}"
-Text="{x:Bind Age, Mode=TwoWay}"
+Text="{x:Bind NewPerson.Name, Mode=TwoWay}"
+Text="{x:Bind NewPerson.Age, Mode=TwoWay}"
 ```
 
 Try it out! Now the data binding works in both directions:

--- a/docs/labor/3-felhasznaloi-felulet/index_ger.md
+++ b/docs/labor/3-felhasznaloi-felulet/index_ger.md
@@ -670,8 +670,8 @@ Starten wir die Anwendung und setzen wir dann einen Haltepunkt im Setter der Eig
 Das liegt daran, dass wir oben die Datenverbindung `OneWay` verwendet haben, die nur eine Datenbindung von der Datenquelle zur Oberfläche ist. **Für den Weg zurück soll der Datenbindungsmodus auf `TwoWay` eingestellt werden.**
 
 ```xml
-Text="{x:Bind Name, Mode=TwoWay}"
-Text="{x:Bind Age, Mode=TwoWay}"
+Text="{x:Bind NewPerson.Name, Mode=TwoWay}"
+Text="{x:Bind NewPerson.Age, Mode=TwoWay}"
 ```
 
 Probieren wir es aus! Auf diese Weise funktioniert die Rückwärts-Datenverbindung: Die angegebene Eigenschaft des Controllers (in unserem Fall Text) und die Datenquelle bleiben bei jeder Richtungsänderung synchron.

--- a/docs/labor/4-tobbszalu/index.md
+++ b/docs/labor/4-tobbszalu/index.md
@@ -397,7 +397,7 @@ A `WorkerThread`-ben folyamatosan futó `while` ciklus ún. aktív várakozást 
 
 A következőkben úgy fogjuk módosítani az alkalmazást, hogy blokkolva várakozzon, amíg adat nem kerül a FIFO-ba (amikor viszont adat kerül bele, azonnal kezdje meg a feldolgozást). Annak jelzésére, hogy van-e adat a sorban egy `ManualResetEvent`-et fogunk használni.
 
-1. Adjunk hozzá egy `MaunalResetEvent` példányt a `DataFifo` osztályunkhoz `_hasData` néven.
+1. Adjunk hozzá egy `ManualResetEvent` példányt a `DataFifo` osztályunkhoz `_hasData` néven.
 
     ```cs
     // A false konstruktor paraméter eredményeképpen kezdetben az esemény nem jelzett (kapu csukva)
@@ -509,7 +509,7 @@ Az előző pontban megoldottuk a jelzést, ám ez önmagában nem sokat ér, his
 
 3. A `lock`-on belüli üresség-vizsgálat szerepe.
 
-    Az előző lépésben a `TryGet`-ben bevezettünk `_hasData` néven egy `MaunalResetEvent` objektumot. Ez pontosan akkor van jelzett állapotban, amikor a FIFO-ban van adat. Kérdés, szükség van-e még most is a lock blokkban az sor üresség vizsgálatra (`if (_innerList.Count > 0)`). Első érzésre redundánsnak gondolhatjuk. De próbáljuk ki, az `if`-ben az ürességvizsgálat helyett adjunk meg egy fix `true` értéket, ezzel semlegesítve az `if` hatását (azért dolgozunk így, hogy könnyű legyen visszacsinálni):
+    Az előző lépésben a `TryGet`-ben bevezettünk `_hasData` néven egy `ManualResetEvent` objektumot. Ez pontosan akkor van jelzett állapotban, amikor a FIFO-ban van adat. Kérdés, szükség van-e még most is a lock blokkban az sor üresség vizsgálatra (`if (_innerList.Count > 0)`). Első érzésre redundánsnak gondolhatjuk. De próbáljuk ki, az `if`-ben az ürességvizsgálat helyett adjunk meg egy fix `true` értéket, ezzel semlegesítve az `if` hatását (azért dolgozunk így, hogy könnyű legyen visszacsinálni):
 
     ```cs hl_lines="4"
         ...

--- a/docs/labor/4-tobbszalu/index_ger.md
+++ b/docs/labor/4-tobbszalu/index_ger.md
@@ -397,7 +397,7 @@ Die Schleife `while`, die in `WorkerThread`ständig läuft, implementiert ein so
 
 Im Folgenden wird die Anwendung so geändert, dass sie in einem blockierten Zustand wartet, bis Daten zum FIFO hinzugefügt werden (aber wenn Daten hinzugefügt werden, beginnt sie sofort mit der Verarbeitung). Um anzuzeigen, ob sich Daten in der Warteschlange befinden, wird `ManualResetEvent`verwendet.
 
-1. Fügen wir eine Instanz von `MaunalResetEvent` zu unserer Klasse `DataFifo` als `_hasData` hinzu.
+1. Fügen wir eine Instanz von `ManualResetEvent` zu unserer Klasse `DataFifo` als `_hasData` hinzu.
 
     ```cs
     // Infolge des Konstruktorparameters false wird das Ereignis anfänglich nicht signalisiert (Tor geschlossen)


### PR DESCRIPTION
## Kisebb javítások

- `ManualResetEvent` typo
- hibás (inverz) német instrukciók
- angol/német instrukciókban a two-way binding elvesztette a `NewPerson.`  prefixet
- egy mondat nem volt lefordítva a német szövegben